### PR TITLE
fix(mcp): update code example highlight line ranges

### DIFF
--- a/mcp/intro.mdx
+++ b/mcp/intro.mdx
@@ -172,7 +172,7 @@ A tool is a function exposed by the server that an AI agent can call using `JSON
 
 Resources are named, read-only data references addressable via URIs. Resources are used to load contextual read-only data into the MCP session.
 
-```python ! mcp-server.py focus=19:24
+```python ! mcp-server.py focus=19:25
 !from ./assets/intro/mcp.py.txt
 ```
 
@@ -180,7 +180,7 @@ Resources are named, read-only data references addressable via URIs. Resources a
 
 Prompts are predefined message templates that servers expose to clients. When invoked with arguments, they return a list of messages (`messages[]`) that the client sends to the LLM to perform a specific task.
 
-```python ! mcp-server.py focus=26:31
+```python ! mcp-server.py focus=27:32
 !from ./assets/intro/mcp.py.txt
 ```
 
@@ -188,7 +188,7 @@ Prompts are predefined message templates that servers expose to clients. When in
 
 Roots are a set of scoped access boundaries provided by the client at handshake. Roots allow the server to limit the visibility of tools, resources, or data based on a given namespace.
 
-```python ! mcp-server.py focus=33:38
+```python ! mcp-server.py focus=34:40
 !from ./assets/intro/mcp.py.txt
 ```
 
@@ -196,7 +196,7 @@ Roots are a set of scoped access boundaries provided by the client at handshake.
 
 A transport defines the communication method the server uses to handle client connections. MCP supports multiple transports, including `stdio` for local execution and `http` for web-based deployment.
 
-```python ! mcp-server.py focus=40:53
+```python ! mcp-server.py focus=45:58
 !from ./assets/intro/mcp.py.txt
 ```
 


### PR DESCRIPTION
Nice that the docs repo is now open source. I saw this issue a few days ago, but could not do anything about it then.

The code highlights on the current [MCP intro page](https://www.speakeasy.com/mcp/intro) are off by a few lines. E.g. for `resources`:

<img width="391" alt="Screenshot 2025-05-21 at 10 45 41" src="https://github.com/user-attachments/assets/8f278fc7-ed48-46b2-ab26-17eaaeeba15c" />

This PR updates the highlight line ranges on this page.
