### PR TITLE
fix(mise guide): Ensure `GITHUB_TOKEN` is provided to mise action

### DIFF
--- a/docs/speakeasy-reference/cli/mise-toolkit.mdx
+++ b/docs/speakeasy-reference/cli/mise-toolkit.mdx
@@ -147,6 +147,8 @@ To use Speakeasy CLI with mise in CI/CD pipelines:
 # Example GitHub Actions workflow
 - name: Install mise
   uses: jdx/mise-action@v2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 - name: Install Speakeasy CLI
   run: mise use aqua:speakeasy-api/speakeasy


### PR DESCRIPTION
Without this the GitHub Action will be severely rate limited when accessing api.github.com (which is how the action downloads the correct version of mise and it's underlying registry).