### PR TITLE
chore: Update public URL instructions for new Dashboard layout

### DIFF
--- a/docs/sdk-docs/integrations/_get-public-url-snippet.mdx
+++ b/docs/sdk-docs/integrations/_get-public-url-snippet.mdx
@@ -4,7 +4,7 @@ import { Screenshot } from "@/mdx/components";
 
 ### Get the API's combined spec public URL from the registry
 
-Navigate to the [Speakeasy Dashboard](https://app.speakeasy.com) and open the **API Registry** tab. Open the `*-with-code-samples` entry for the API.
+Navigate to the [Speakeasy Dashboard](https://app.speakeasy.com) and open the **API Registry** overview. Select the relevant API and open the entry labeled with type `Combined Spec`. This is typically at the bottom under "Related Documents".
 
 <Screenshot 
   variant="web"
@@ -18,7 +18,7 @@ Navigate to the [Speakeasy Dashboard](https://app.speakeasy.com) and open the **
 > has an [automatic code sample
 > URL](/docs/sdk-docs/code-samples/automated-code-sample-urls) configured.
 
-From the registry entry's page, copy the provided public URL.
+From the registry entry's page, copy the provided public URL using the "Share" button on the top right.
 
 <Screenshot 
   variant="web"


### PR DESCRIPTION
Updating instructions to fetch combined spec URL to match current Dashboard. This will be accompanied by an update to the screenshots themselves, which needs to be done in the marketing site repo